### PR TITLE
Undefined method handling

### DIFF
--- a/lib/umts-custom-cops/predicate_method_matcher.rb
+++ b/lib/umts-custom-cops/predicate_method_matcher.rb
@@ -18,6 +18,7 @@ module RuboCop
           expectation = node.child_nodes.first
           return unless expectation.method_name == :expect
           match_value = expectation.child_nodes.first
+          return unless match_value.class == RuboCop::AST::SendNode
           return unless match_value.method_name.to_s.end_with? '?'
           matcher = node.child_nodes[1]
           if GENERIC_EQUALITY_MATCHERS.include? matcher.method_name

--- a/lib/umts-custom-cops/version.rb
+++ b/lib/umts-custom-cops/version.rb
@@ -1,3 +1,3 @@
 module UmtsCustomCops
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/custom-cops/predicate_method_matcher_spec.rb
+++ b/spec/custom-cops/predicate_method_matcher_spec.rb
@@ -50,6 +50,10 @@ describe RuboCop::Cop::UmtsCustomCops::PredicateMethodMatcher do
     it 'skips nodes without expect' do
       inspect_source 'stuff.method?.should be true'
     end
+    it 'skips any nodes with mocks' do
+      inspect_source 'expect(Object).to receive(:method).and_return object'
+      inspect_source 'expect(Object.method).to receive(:method).and_return object'
+    end
     it 'skips nodes without to or not_to' do
       inspect_source 'assert(stuff.method?.eql? true)'
     end


### PR DESCRIPTION
`send_node` threw an error when checking an expectation like this:
`'expect(Object).to receive(:method).and_return object'`

But not when it was like this:
`'expect(Object.method).to receive(:method).and_return object'`

The reason for this is because the first child node of the first child node of the given node (no, that's not a typo) ended up being of the class RuboCop::AST::Node in the first example, which threw an error when `method_name` was called on it (undefined method). Since the `on_send` method is expecting the first child node of the first child node of the given node to be a Rubocop::AST::SendNode, I simply made the method `return` if it was not and wrote a test using the failure line. It only happens, I think, in that specific type of expectation. (I have found no other failure cases, but this should also cover those).

Wish I could ELI5 this is the best I got rn