### PR TITLE
Node patterns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,14 @@
 Metrics/LineLength:
   Max: 100
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'lib/umts-custom-cops/version.rb'
 
-Style/FileName:
+Naming/FileName:
   Enabled: false

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'custom/cops'
+require 'umts-custom-cops'
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require 'irb'
-IRB.start
+require 'pry'
+Pry.start

--- a/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
+++ b/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
@@ -1,3 +1,5 @@
+require 'rubocop'
+
 module RuboCop
   module Cop
     module UmtsCustomCops

--- a/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
+++ b/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
@@ -6,10 +6,8 @@ module RuboCop
       # Prefer the easier-to-read be matcher for non-duplicable types.
       #
       # See the specs for examples.
-
-      # rubocop:disable Metrics/AbcSize
       class BeMatcherForNonDuplicableTypes < Cop
-        MSG = 'Prefer `be` matcher to `eq` or `eql` for non-duplicable types.'
+        MSG = 'Prefer `be` matcher to `eq` or `eql` for non-duplicable types.'.freeze
 
         def_node_matcher :eq_on_non_duplicable_type?, <<-PATTERN
           (send

--- a/lib/umts-custom-cops/predicate_method_matcher.rb
+++ b/lib/umts-custom-cops/predicate_method_matcher.rb
@@ -5,7 +5,8 @@ module RuboCop
     module UmtsCustomCops
       # See the specs for examples.
       class PredicateMethodMatcher < Cop
-        MSG = 'Prefer predicate matcher over checking the return value of a predicate method.'
+        MESSAGE =
+          'Prefer predicate matcher over checking the return value of a predicate method.'.freeze
 
         def_node_matcher :generic_equality_expectation, <<-PATTERN
         (send
@@ -27,15 +28,13 @@ module RuboCop
         )
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_send(node)
           ends_with_question_mark = ->(method) { method.to_s.end_with? '?' }
 
           if generic_equality_expectation(node, &ends_with_question_mark) ||
              boolean_equality_expectation(node, &ends_with_question_mark)
 
-            add_offense node, location: :expression, message: MSG
+            add_offense node, location: :expression, message: MESSAGE
           end
         end
       end

--- a/lib/umts-custom-cops/predicate_method_matcher.rb
+++ b/lib/umts-custom-cops/predicate_method_matcher.rb
@@ -7,25 +7,36 @@ module RuboCop
       class PredicateMethodMatcher < Cop
         MSG = 'Prefer predicate matcher over checking the return value of a predicate method.'
 
-        BOOLEAN_EQUALITY_MATCHERS = %i(be_true be_false)
-        GENERIC_EQUALITY_MATCHERS = %i(be eq eql equal)
+        def_node_matcher :generic_equality_expectation, <<-PATTERN
+        (send
+          (send _context :expect
+            (send ... $_expectation)
+          ) {:to :not_to}
+          (send _context {:be :eq :eql :equal}
+            {true false}
+          )
+        )
+        PATTERN
+
+        def_node_matcher :boolean_equality_expectation, <<-PATTERN
+        (send
+          (send _context :expect
+            (send ... $_expectation)
+          ) {:to :not_to}
+          (send _context {:be_true :be_false})
+        )
+        PATTERN
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_send(node)
-          return unless %i(to not_to).include? node.method_name
-          return unless node.child_nodes
-          expectation = node.child_nodes.first
-          return unless expectation.method_name == :expect
-          match_value = expectation.child_nodes.first
-          return unless match_value.method_name.to_s.end_with? '?'
-          matcher = node.child_nodes[1]
-          if GENERIC_EQUALITY_MATCHERS.include? matcher.method_name
-            matcher_arg = matcher.child_nodes.first
-            return unless matcher_arg.true_type? || matcher_arg.false_type?
-          else return unless BOOLEAN_EQUALITY_MATCHERS.include? matcher.method_name
+          ends_with_question_mark = ->(method) { method.to_s.end_with? '?' }
+
+          if generic_equality_expectation(node, &ends_with_question_mark) ||
+             boolean_equality_expectation(node, &ends_with_question_mark)
+
+            add_offense node, location: :expression, message: MSG
           end
-          add_offense node, location: :expression, message: MSG
         end
       end
     end

--- a/lib/umts-custom-cops/predicate_method_matcher.rb
+++ b/lib/umts-custom-cops/predicate_method_matcher.rb
@@ -1,4 +1,4 @@
-require 'pry-byebug'
+require 'rubocop'
 
 module RuboCop
   module Cop

--- a/lib/umts-custom-cops/version.rb
+++ b/lib/umts-custom-cops/version.rb
@@ -1,3 +1,3 @@
 module UmtsCustomCops
-  VERSION = '0.3.1'
+  VERSION = '0.3.1'.freeze
 end

--- a/lib/umts-custom-cops/version.rb
+++ b/lib/umts-custom-cops/version.rb
@@ -1,3 +1,3 @@
 module UmtsCustomCops
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
+++ b/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
@@ -27,12 +27,12 @@ describe RuboCop::Cop::UmtsCustomCops::BeMatcherForNonDuplicableTypes do
 
   context 'autocorrect' do
     it 'corrects `eq` to `be`' do
-      expect(autocorrect_source 'expect(stuff).to eq true')
+      expect(autocorrect_source('expect(stuff).to eq true'))
         .to eql 'expect(stuff).to be true'
     end
 
     it 'corrects `eql` to `be`' do
-      expect(autocorrect_source 'expect(stuff).to eql true')
+      expect(autocorrect_source('expect(stuff).to eql true'))
         .to eql 'expect(stuff).to be true'
     end
   end

--- a/spec/custom-cops/predicate_method_matcher_spec.rb
+++ b/spec/custom-cops/predicate_method_matcher_spec.rb
@@ -50,6 +50,9 @@ describe RuboCop::Cop::UmtsCustomCops::PredicateMethodMatcher do
     it 'skips nodes without expect' do
       inspect_source 'stuff.method?.should be true'
     end
+    it 'skips expectations without method calls ' do
+      inspect_source 'expect(Object).to receive(:a_method)'
+    end
     it 'skips nodes without to or not_to' do
       inspect_source 'assert(stuff.method?.eql? true)'
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,6 @@ SimpleCov.start do
 end
 
 require 'rubocop/rspec/support'
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'umts-custom-cops'

--- a/umts-custom-cops.gemspec
+++ b/umts-custom-cops.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'umts-custom-cops/version'
 
@@ -22,8 +21,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rspec', '~> 3.0'
@@ -31,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', File.open('.bundler.version').read.strip
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
A rewrite attempt that makes use of [node patterns](https://docs.rubocop.org/en/latest/node_pattern/) to find the offending nodes. Happens to also address the same failure as #6.