### PR TITLE
Remove integers from the list of "non-duplicables"

### DIFF
--- a/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
+++ b/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
@@ -14,7 +14,7 @@ module RuboCop
             _expectation {:to :not_to}
             (send
               _context {:eq :eql}
-              {true false nil int}
+              {true false nil}
             )
           )
         PATTERN

--- a/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
+++ b/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
@@ -14,7 +14,6 @@ describe RuboCop::Cop::UmtsCustomCops::BeMatcherForNonDuplicableTypes do
     it('finds an expectation with eql/true') { inspect_source 'expect(stuff).to eql true' }
     it('finds an expectation with false')    { inspect_source 'expect(stuff).to eql false' }
     it('finds an expectation with nil')      { inspect_source 'expect(stuff).not_to eql nil' }
-    it('finds an expectation with a Fixnum') { inspect_source 'expect(stuff).to eql 3' }
   end
 
   context 'non-failure cases' do

--- a/umts-custom-cops.gemspec
+++ b/umts-custom-cops.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', '~> 3.0'
   spec.add_dependency 'rubocop', '0.65.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'bundler', '~> 2.1', '>= 2.1.4'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
It _often_ works to `expect(something).to be(4)`, but not always:

```
expect(4/1r).to eq(4)  #passes, our cop complains
expect(4/1r).to be(4)  #fails
```

Closes #9