### PR TITLE
Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
 Metrics/LineLength:
   Max: 100
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
 AllCops:
+  NewCops: enable
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/BlockLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.9
-  - 2.5.7
+  - 2.5.8
   - 2.6.5
-  - 2.7.0
+  - 2.7.2
+  - 3.0.0
 env: CODECLIMATE_REPO_TOKEN=c356c22cc5b342d3cba9a1fb9d71b63b52de9b9daa1f54c07f959f90da05c8ff
 before_install:
   - gem update --system
   - gem install bundler
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - bundle exec rake
-after_success:
-  - bundle exec codeclimate-test-reporter
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 notifications:
   email:
     on_success: change

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in custom-cops.gemspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 David Faulkenberry
+Copyright (c) 2020 UMass Transit Services
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 Custom Rubocops, currently all related to RSpec, used for UMass Transit's
 internal Rails development purposes.
 
-Primary contributor is @dfaulken.
-
 A lot of the ideas for this came from some reading of the rubocop source
 code, so thanks to the RuboCop team for making it public.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'umts-custom-cops'

--- a/lib/umts-custom-cops.rb
+++ b/lib/umts-custom-cops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'umts-custom-cops/version'
 
 require 'umts-custom-cops/be_matcher_for_non_duplicable_types'

--- a/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
+++ b/lib/umts-custom-cops/be_matcher_for_non_duplicable_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 
 module RuboCop
@@ -7,7 +9,7 @@ module RuboCop
       #
       # See the specs for examples.
       class BeMatcherForNonDuplicableTypes < Cop
-        MSG = 'Prefer `be` matcher to `eq` or `eql` for non-duplicable types.'.freeze
+        MSG = 'Prefer `be` matcher to `eq` or `eql` for non-duplicable types.'
 
         def_node_matcher :eq_on_non_duplicable_type?, <<-PATTERN
           (send

--- a/lib/umts-custom-cops/predicate_method_matcher.rb
+++ b/lib/umts-custom-cops/predicate_method_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 
 module RuboCop
@@ -6,7 +8,7 @@ module RuboCop
       # See the specs for examples.
       class PredicateMethodMatcher < Cop
         MESSAGE =
-          'Prefer predicate matcher over checking the return value of a predicate method.'.freeze
+          'Prefer predicate matcher over checking the return value of a predicate method.'
 
         def_node_matcher :generic_equality_expectation, <<-PATTERN
         (send

--- a/lib/umts-custom-cops/version.rb
+++ b/lib/umts-custom-cops/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UmtsCustomCops
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.3'
 end

--- a/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
+++ b/spec/custom-cops/be_matcher_for_non_duplicable_types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::UmtsCustomCops::BeMatcherForNonDuplicableTypes do

--- a/spec/custom-cops/predicate_method_matcher_spec.rb
+++ b/spec/custom-cops/predicate_method_matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::UmtsCustomCops::PredicateMethodMatcher do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 require 'simplecov'
 

--- a/umts-custom-cops.gemspec
+++ b/umts-custom-cops.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rspec', '~> 3.0'
-  spec.add_dependency 'rubocop', '0.65.0'
+  spec.add_dependency 'rubocop', '~> 1.10'
 
-  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/umts-custom-cops.gemspec
+++ b/umts-custom-cops.gemspec
@@ -23,10 +23,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.5.0'
+
   spec.add_dependency 'rubocop', '~> 1.10'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/umts-custom-cops.gemspec
+++ b/umts-custom-cops.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'umts-custom-cops/version'
@@ -15,10 +17,11 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-  else fail 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
-  end
+  raise <<~MSG unless spec.respond_to?(:metadata)
+    RubyGems 2.0 or newer is required to protect against public gem pushes.
+  MSG
+
+  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
We were pinned to exacty version 0.65.0 of Rubocop, and we didn't need to be.

I also moved up all of the supported versions of Ruby and did a quick rubocop run once I had upgraded it.